### PR TITLE
chore(deps): update dependency typescript to v4.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
     "tslib": "2.4.0",
-    "typescript": "4.7.4",
+    "typescript": "4.8.3",
     "urql": "3.0.3",
     "vue": "3.2.39",
     "vue-apollo-smart-ops": "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12746,10 +12746,10 @@ typescript-json-schema@0.54.0:
     typescript "~4.6.0"
     yargs "^17.1.1"
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 typescript@~4.6.0:
   version "4.6.4"


### PR DESCRIPTION
## Description
chore(deps): update dependency typescript to v4.8.3 #8286

Related # (issue)
https://github.com/dotansimha/graphql-code-generator/pull/8286#issuecomment-1228254457

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

